### PR TITLE
Fix measureme command load path

### DIFF
--- a/bin/measureme
+++ b/bin/measureme
@@ -19,14 +19,8 @@ end
 begin
   require 'measureme'
 rescue LoadError
-  raise if $!.to_s !~ /measureme/
-  libdir = File.expand_path("../../lib", __FILE__).sub(/^#{Dir.pwd}/, '.')
-  if !$:.include?(libdir)
-    $:.unshift libdir
-    require File.expand_path('../../.bundle/environment', __FILE__)
-    retry
-  end
-  raise
+  libdir = File.expand_path('../../lib', __FILE__)
+  require File.join(libdir, 'measureme')
 end
 
 m = MeasureMe::Measurer.new


### PR DESCRIPTION
## Summary
- fix require fallback in `bin/measureme` so it runs from source

## Testing
- `ruby bin/measureme | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6840624ff75c832a9e44777c613cd717